### PR TITLE
fix tx error when tx has error but the caller not return immediately

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -166,7 +166,9 @@ func (tx *DBTx) Query(sql string, args ...interface{}) (*sql.Rows, error) {
 		log.Println("DEBUG: ", sql, args)
 	}
 	result, err := tx.tx.Query(sql, args...)
-	tx.err = err
+	if err != nil {
+		tx.err = err
+	}
 	return result, tx.err
 }
 
@@ -184,6 +186,9 @@ func (tx *DBTx) Exec(sql string, args ...interface{}) (sql.Result, error) {
 		log.Println("DEBUG: ", sql, args)
 	}
 	result, err := tx.tx.Exec(sql, args...)
+	if err != nil {
+		tx.err = err
+	}
 	tx.err = err
 	return result, tx.err
 }


### PR DESCRIPTION
## bug case:
```go
tx,err:=model.MYSQL().BeginTx()
if err!=nil{
//handle error
}
defer tx.Close()
//this will be a  failed db operation
if _,err:=model.BarMgr(tx).Create(barObj);err!=nil{
//it will has error,but not return here
}
//then the tx will go on 
//next is a success db operation
if _,err:=model.FooMgr(tx).Create(fooObj);err!=nil{
//will not return here
}
```
## what happened?

the `tx` has an error in first db operation(BarMgr) but this error will be overrided by next success db operation(FooMgr)

## fixed 

just drop nil error.And keep the err during the entire tx.
