### PR TITLE
parser: fix misorder of the pk keys

### DIFF
--- a/example/yaml/user.yaml
+++ b/example/yaml/user.yaml
@@ -31,7 +31,7 @@ User:
     - DeletedAt: timeint
       flags: [nullable]
   uniques: [[Mailbox, Password]]
-  primary: [Id,SubID]
+  primary: [Id,SubID,Name]
 
 UserBaseInfo:
   dbs: [mysql]

--- a/parser/primary.key.go
+++ b/parser/primary.key.go
@@ -51,7 +51,7 @@ func (pk *PrimaryKey) IsRange() bool {
 	}
 	c := len(fs)
 	if c > 0 {
-		return pk.Fields[c-1].IsNumber()
+		return fs[c-1].IsNumber()
 	}
 	return false
 }


### PR DESCRIPTION
Bug:

assume you have a yaml that defines with the new `norange` key
```yaml
User:
Id: int64
flags: [norange]
SubId: Int64
flags: [norange]
Name: string
primarys: [Id,SubId,Name]
```

It will create ZSet as before, but, It should have no ZSet. And the last pk field is `Name`, it's a string not a int.